### PR TITLE
Support sub benchmarks

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -15,6 +15,7 @@ var bTests = []struct {
 	{"BenchmarkF2_F0000000-4		50000000	        29.4 ns/op", "F2", "F0000000", 29.4},
 	{"BenchmarkF0_FF-2		10000000	        37.4 ns/op", "F0", "FF", 37.4},
 	{"BenchmarkF_0-2		40000000	        11.2 ns/op", "F", "0", 11.2},
+	{"BenchmarkF3/quicksort_100-4		40000000	        11.2 ns/op", "F3/quicksort", "100", 11.2},
 }
 
 func TestParser(t *testing.T) {

--- a/parse.go
+++ b/parse.go
@@ -8,7 +8,7 @@ import (
 
 // Coder should use following naming convention for Benchmark functions
 // Naming convention: Benchmark[Function_name]_[Function_argument](b *testing.B)
-var re *regexp.Regexp = regexp.MustCompile(`Benchmark([a-zA-Z0-9]+)_([_a-zA-Z0-9]+)-([0-9]+)$`)
+var re *regexp.Regexp = regexp.MustCompile(`Benchmark([a-zA-Z0-9/]+)_([_a-zA-Z0-9]+)-([0-9]+)$`)
 
 // Storage for Func(Arg)=Result relations
 type BenchArgSet map[string]float64


### PR DESCRIPTION
```golang
func BenchmarkMerge(b *testing.B) {
  b.Run("hash", func(b *testing.B) {
  }
  b.Run("array", func(b *testing.B) {
  }
}
```

Would generate output:

```
BenchmarkMerge/hash-4
BenchmarkMerge/array-4
```

Add in the list of valid characters `/` resolve problem